### PR TITLE
Update to run under rust 1.3.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![crate_name = "jade"]
-#![feature(collections)]
 #![allow(dead_code)]
 #![allow(unused_attributes)]
 #![allow(unused_variables)]


### PR DESCRIPTION
Quick-and-dirty to get tests running under Rust 1.3.0.

_For your trouble, here's a cute animal picture!_

![via Buzzfeed](http://ak-hdl.buzzfed.com/static/2015-07/30/17/enhanced/webdr15/enhanced-22540-1438290024-1.jpg)
